### PR TITLE
Gather code coverage for production code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ DerivedData
 *.hmap
 *.ipa
 *.xcuserstate
+vendor/
 
 # CocoaPods
 #

--- a/.slather.yml
+++ b/.slather.yml
@@ -1,0 +1,8 @@
+coverage_service: cobertura_xml
+xcodeproj: MusicNotationCore/MusicNotationCore.xcodeproj
+scheme: MusicNotationCoreMac
+source_directory: Sources
+output_directory: vendor/tests/coverage
+ignore:
+  - Tests/*
+  - MusicNotationCore/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: swift
 osx_image: xcode11
+before_install: rvm use $RVM_RUBY_VERSION
+install: bundle install --without=documentation --path ../travis_bundle_dir
 script:
 
   - set -o pipefail
@@ -10,7 +12,8 @@ script:
   - xcodebuild build -project MusicNotationCore/MusicNotationCore.xcodeproj -scheme MusicNotationCoreTV -sdk appletvos | xcpretty
   - xcodebuild build -project MusicNotationCore/MusicNotationCore.xcodeproj -scheme MusicNotationCoreWatch -sdk watchos | xcpretty
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  - bundle exec slather
+  - bash <(curl -s https://codecov.io/bash) -f vendor/tests/coverage/cobertura.xml -X coveragepy -X gcov -X xcode
 notifications:
   slack: musicnotationswift:GAuOCY6YxRaZHrDvGRXRF9Im
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+gem 'slather'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,45 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (3.0.1)
+    activesupport (4.2.11.1)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    atomos (0.1.3)
+    claide (1.0.3)
+    clamp (1.3.1)
+    colored2 (3.1.2)
+    concurrent-ruby (1.1.5)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
+    mini_portile2 (2.4.0)
+    minitest (5.13.0)
+    nanaimo (0.2.6)
+    nokogiri (1.10.5)
+      mini_portile2 (~> 2.4.0)
+    slather (2.4.7)
+      CFPropertyList (>= 2.2, < 4)
+      activesupport (>= 4.0.2, < 5)
+      clamp (~> 1.3)
+      nokogiri (~> 1.8)
+      xcodeproj (~> 1.7)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+    xcodeproj (1.13.0)
+      CFPropertyList (>= 2.3.3, < 4.0)
+      atomos (~> 0.1.3)
+      claide (>= 1.0.2, < 2.0)
+      colored2 (~> 3.1)
+      nanaimo (~> 0.2.6)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  slather
+
+BUNDLED WITH
+   2.0.2

--- a/MusicNotationCore/MusicNotationCore.xcodeproj/xcshareddata/xcschemes/MusicNotationCoreMac.xcscheme
+++ b/MusicNotationCore/MusicNotationCore.xcodeproj/xcshareddata/xcschemes/MusicNotationCoreMac.xcscheme
@@ -26,8 +26,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "27CE86A71E750534007AD729"
+            BuildableName = "MusicNotationCoreMac.framework"
+            BlueprintName = "MusicNotationCoreMac"
+            ReferencedContainer = "container:MusicNotationCore.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -40,17 +50,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "27CE86A71E750534007AD729"
-            BuildableName = "MusicNotationCoreMac.framework"
-            BlueprintName = "MusicNotationCoreMac"
-            ReferencedContainer = "container:MusicNotationCore.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -71,8 +70,6 @@
             ReferencedContainer = "container:MusicNotationCore.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/MusicNotationCore/MusicNotationCore.xcodeproj/xcshareddata/xcschemes/MusicNotationCoreTV.xcscheme
+++ b/MusicNotationCore/MusicNotationCore.xcodeproj/xcshareddata/xcschemes/MusicNotationCoreTV.xcscheme
@@ -29,8 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -51,8 +49,6 @@
             ReferencedContainer = "container:MusicNotationCore.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/MusicNotationCore/MusicNotationCore.xcodeproj/xcshareddata/xcschemes/MusicNotationCoreWatch.xcscheme
+++ b/MusicNotationCore/MusicNotationCore.xcodeproj/xcshareddata/xcschemes/MusicNotationCoreWatch.xcscheme
@@ -29,8 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -51,8 +49,6 @@
             ReferencedContainer = "container:MusicNotationCore.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/MusicNotationCore/MusicNotationCore.xcodeproj/xcshareddata/xcschemes/MusicNotationCoreiOS.xcscheme
+++ b/MusicNotationCore/MusicNotationCore.xcodeproj/xcshareddata/xcschemes/MusicNotationCoreiOS.xcscheme
@@ -29,8 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -51,8 +49,6 @@
             ReferencedContainer = "container:MusicNotationCore.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
I have added slather for generating code coverage report in .xml just for target which is the framework production code, excluding any testing code, which doesn't interest the end-user.